### PR TITLE
perf: React cache() で getCourseById の二重クエリを解消

### DIFF
--- a/lib/courses.ts
+++ b/lib/courses.ts
@@ -1,3 +1,4 @@
+import { cache } from "react";
 import { createClient } from "@/lib/supabase/server";
 import type { Tables } from "@/types/database";
 
@@ -14,7 +15,7 @@ export async function getCourses(): Promise<Course[]> {
   return data ?? [];
 }
 
-export async function getCourseById(id: string): Promise<Course | null> {
+export const getCourseById = cache(async (id: string): Promise<Course | null> => {
   const supabase = await createClient();
   const { data, error } = await supabase
     .from("courses")
@@ -24,4 +25,4 @@ export async function getCourseById(id: string): Promise<Course | null> {
 
   if (error) return null;
   return data;
-}
+});


### PR DESCRIPTION
## Summary

- `getCourseById` を React の `cache()` でラップし、同一リクエスト内での重複 DB クエリを解消
- `generateMetadata` とページ本体の両方から呼ばれていた DB クエリが 1 回に削減される

## Changes

- `lib/courses.ts`: `getCourseById` を `cache()` でメモ化

## Related Issue

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **パフォーマンス改善**
  * コース検索機能のキャッシング機構を最適化し、応答時間を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->